### PR TITLE
Fix mongodb-parks when built with mongodb 3.6

### DIFF
--- a/mongodb/config/mongod.conf
+++ b/mongodb/config/mongod.conf
@@ -57,12 +57,6 @@ net:
       pathPrefix: {{pkg.svc_files_path}}/tmp
       filePermissions: {{cfg.mongod.net.unix_domain_socket.file_permissions}}
 
-net:
-   http:
-      enabled: {{cfg.mongod.net.http.enabled}}
-      JSONPEnabled: {{cfg.mongod.net.http.jsonp_enabled}}
-      RESTInterfaceEnabled: {{cfg.mongod.net.http.rest_interface_enabled}}
-
 {{~#if cfg.mongod.net.ssl.enabled}}
 net:
    ssl:


### PR DESCRIPTION
MongoDB 3.6 removes the deprecated net.http settings. You cannot set net.http settings on MongoDB 3.6+ deployments.

https://docs.cloudmanager.mongodb.com/reference/deployment-advanced-options/#net-http

Results in 
```
hab-launch(SV): Child for service 'mongodb-parks.default' with PID 1950 exited with code exit code: 2
mongodb-parks.default(SV): Starting service as user=hab, group=hab
mongodb-parks.default(O): Unrecognized option: net.http.RESTInterfaceEnabled
mongodb-parks.default(O): try 'mongod --help' for more information
```
for all net.http settings

Signed-off-by: Gavin Reynolds <gavin@chef.io>